### PR TITLE
Update MongoSession.php

### DIFF
--- a/MongoSession.php
+++ b/MongoSession.php
@@ -292,7 +292,7 @@ class MongoSession {
      */
     public function destroy($id)
     {
-        $this->_mongo->remove(array('session_id' => $id), true);
+        $this->_mongo->remove(array('session_id' => $id), array('w' => true));
         return true;
     }
 


### PR DESCRIPTION
"safe" is now deprecated....

http://php.net/manual/en/mongocollection.remove.php

i think you can use $options without error but send "true" is a fatal error now...
